### PR TITLE
Source functions with .

### DIFF
--- a/install_files/init.d/razer_bcd
+++ b/install_files/init.d/razer_bcd
@@ -27,7 +27,7 @@ if [ -f /etc/default/razer_bcd ] ; then
 fi
 
 # Load in the binding and unbinding functions
-source $FUNCTIONS
+. $FUNCTIONS
 
 set -e
 


### PR DESCRIPTION
Looks like this was an oversight, the other init files already source things properly.